### PR TITLE
feat: Implemented RebalanceRevokeMode

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -7,14 +7,12 @@
 package fs2.kafka
 
 import java.util
-
 import scala.annotation.nowarn
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 import scala.util.matching.Regex
-
-import cats.{Foldable, Functor, Reducible}
-import cats.data.{NonEmptySet, OptionT}
+import cats.{Applicative, Foldable, Functor, Reducible}
+import cats.data.{Chain, NonEmptySet, OptionT}
 import cats.effect.*
 import cats.effect.implicits.*
 import cats.effect.std.*
@@ -28,7 +26,6 @@ import fs2.kafka.internal.converters.collection.*
 import fs2.kafka.internal.syntax.*
 import fs2.kafka.internal.KafkaConsumerActor.*
 import fs2.kafka.internal.LogEntry.{RevokedPreviousFetch, StoredFetch}
-
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetAndTimestamp}
 import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition}
 
@@ -151,7 +148,8 @@ object KafkaConsumer {
         def partitionStream(
           streamId: StreamId,
           partition: TopicPartition,
-          assignmentRevoked: F[Unit]
+          assignmentRevoked: F[Unit],
+          signalCompletion: F[Unit]
         ): Stream[F, CommittableConsumerRecord[F, K, V]] = Stream.force {
           for {
             chunks      <- chunkQueue
@@ -238,7 +236,9 @@ object KafkaConsumer {
                     .fromQueueNoneTerminated(chunks)
                     .flatMap(Stream.chunk)
                     .covary[F]
-                    .onFinalize(dequeueDone.complete(()).void)
+                    //Previously all the revoke logic was done on the polling stream, not handling stream
+                    //with new `signalCompletion` there is possibility for more graceful consumer revoke logic
+                    .onFinalize(dequeueDone.complete(()) *> signalCompletion)
                 }
             }
             .flatten
@@ -246,15 +246,15 @@ object KafkaConsumer {
 
         def enqueueAssignment(
           streamId: StreamId,
-          assigned: Map[TopicPartition, Deferred[F, Unit]],
+          assigned: Map[TopicPartition, AssignmentSignals[F]],
           partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] =
           stopConsumingDeferred
             .tryGet
             .flatMap {
               case None =>
-                val assignment: PartitionsMap = assigned.map { case (partition, finisher) =>
-                  partition -> partitionStream(streamId, partition, finisher.get)
+                val assignment = assigned.map { case (partition, assignmentSignals) =>
+                  partition -> partitionStream(streamId, partition, assignmentSignals.awaitStreamTerminationSignal, assignmentSignals.signalStreamFinished.void)
                 }
                 partitionsMapQueue.offer(Some(assignment))
               case Some(()) =>
@@ -263,24 +263,24 @@ object KafkaConsumer {
 
         def onRebalance(
           streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
           partitionsMapQueue: PartitionsMapQueue
         ): OnRebalance[F] =
           OnRebalance(
             onRevoked = revoked => {
               for {
                 finishers <- assignmentRef.modify(_.partition(entry => !revoked.contains(entry._1)))
-                _         <- finishers.toVector.traverse { case (_, finisher) => finisher.complete(()) }
-              } yield ()
+                revokeFinishers  <- Chain
+                  .fromIterableOnce(finishers)
+                  .traverse {
+                    case (_, assignmentSignals) =>
+                      assignmentSignals.signalStreamToTerminate.as(assignmentSignals.awaitStreamFinishedSignal)
+                  }
+              } yield revokeFinishers
             },
             onAssigned = assignedPartitions => {
               for {
-                assignment <- assignedPartitions
-                                .toVector
-                                .traverse { partition =>
-                                  Deferred[F, Unit].map(partition -> _)
-                                }
-                                .map(_.toMap)
+                assignment <- buildAssignment(assignedPartitions)
                 _ <- assignmentRef.update(_ ++ assignment)
                 _ <- enqueueAssignment(
                        streamId = streamId,
@@ -291,11 +291,29 @@ object KafkaConsumer {
             }
           )
 
+        def buildAssignment(
+          assignedPartitions: SortedSet[TopicPartition]
+        ): F[Map[TopicPartition, AssignmentSignals[F]]] = {
+          assignedPartitions
+            .toVector
+            .traverse { partition =>
+              settings.rebalanceRevokeMode match {
+                case RebalanceRevokeMode.EagerMode =>
+                  Deferred[F, Unit].map(streamFinisher => partition -> AssignmentSignals.eager(streamFinisher))
+                case RebalanceRevokeMode.GracefulMode =>
+                  (Deferred[F, Unit], Deferred[F, Unit]).mapN { (streamFinisher, revokeFinisher) =>
+                    partition -> AssignmentSignals.graceful(streamFinisher, revokeFinisher)
+                  }
+              }
+            }
+            .map(_.toMap)
+        }
+
         def requestAssignment(
           streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
           partitionsMapQueue: PartitionsMapQueue
-        ): F[Map[TopicPartition, Deferred[F, Unit]]] = {
+        ): F[Map[TopicPartition, AssignmentSignals[F]]] = {
           val assignment = this.assignment(
             Some(
               onRebalance(
@@ -312,18 +330,13 @@ object KafkaConsumer {
                 F.pure(Map.empty)
 
               case Right(assigned) =>
-                assigned
-                  .toVector
-                  .traverse { partition =>
-                    Deferred[F, Unit].map(partition -> _)
-                  }
-                  .map(_.toMap)
+                buildAssignment(assigned)
             }
         }
 
         def initialEnqueue(
           streamId: StreamId,
-          assignmentRef: Ref[F, Map[TopicPartition, Deferred[F, Unit]]],
+          assignmentRef: Ref[F, Map[TopicPartition, AssignmentSignals[F]]],
           partitionsMapQueue: PartitionsMapQueue
         ): F[Unit] =
           for {
@@ -343,7 +356,7 @@ object KafkaConsumer {
                 partitionsMapQueue <- Stream.eval(Queue.unbounded[F, Option[PartitionsMap]])
                 streamId           <- Stream.eval(streamIdRef.modify(n => (n + 1, n)))
                 assignmentRef <- Stream
-                                   .eval(Ref[F].of(Map.empty[TopicPartition, Deferred[F, Unit]]))
+                                   .eval(Ref[F].of(Map.empty[TopicPartition, AssignmentSignals[F]]))
                 _ <- Stream.eval(
                        initialEnqueue(
                          streamId,
@@ -432,7 +445,9 @@ object KafkaConsumer {
                 assignmentRef.updateAndGet(_ ++ assigned).flatMap(updateQueue.offer),
             onRevoked = revoked =>
               initialAssignmentDone >>
-                assignmentRef.updateAndGet(_ -- revoked).flatMap(updateQueue.offer)
+                assignmentRef.updateAndGet(_ -- revoked)
+                  .flatMap(updateQueue.offer)
+                  .as(Chain.empty)
           )
 
         Stream
@@ -822,6 +837,40 @@ object KafkaConsumer {
     def consumeChunk(processor: Chunk[ConsumerRecord[K, V]] => F[CommitNow])(implicit
       F: Concurrent[F]
     ): F[Nothing] = self.evalMap(_.consumeChunk(processor)).compile.onlyOrError
+
+  }
+
+  /**
+   * Utility class to provide clarity for internals.
+   * Goal is to make [[RebalanceRevokeMode]] transparent to the rest of implementation internals.
+   * @tparam F effect used
+   */
+  private sealed abstract class AssignmentSignals[F[_]] {
+    def signalStreamToTerminate: F[Boolean]
+    def awaitStreamTerminationSignal: F[Unit]
+    def signalStreamFinished: F[Boolean]
+    def awaitStreamFinishedSignal: F[Unit]
+  }
+
+  private object AssignmentSignals {
+
+    def eager[F[_]: Applicative](streamFinisher: Deferred[F, Unit]): AssignmentSignals[F] = EagerSignals(streamFinisher)
+    def graceful[F[_]](streamFinisher: Deferred[F, Unit], revokeFinisher: Deferred[F, Unit]): AssignmentSignals[F] =
+      GracefulSignals[F](streamFinisher, revokeFinisher)
+
+    final case class EagerSignals[F[_]: Applicative](streamFinisher: Deferred[F, Unit]) extends AssignmentSignals[F] {
+      override def signalStreamToTerminate: F[Boolean] = streamFinisher.complete(())
+      override def awaitStreamTerminationSignal: F[Unit] = streamFinisher.get
+      override def signalStreamFinished: F[Boolean] = true.pure[F]
+      override def awaitStreamFinishedSignal: F[Unit] = ().pure[F]
+    }
+
+    final case class GracefulSignals[F[_]](streamFinisher: Deferred[F, Unit], revokeFinisher: Deferred[F, Unit]) extends AssignmentSignals[F] {
+      override def signalStreamToTerminate: F[Boolean] = streamFinisher.complete(())
+      override def awaitStreamTerminationSignal: F[Unit] = streamFinisher.get
+      override def signalStreamFinished: F[Boolean] = revokeFinisher.complete(())
+      override def awaitStreamFinishedSignal: F[Unit] = revokeFinisher.get
+    }
 
   }
 

--- a/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
+++ b/modules/core/src/main/scala/fs2/kafka/RebalanceRevokeMode.scala
@@ -1,0 +1,42 @@
+package fs2.kafka
+
+/**
+ * The available options for [[ConsumerSettings#rebalanceRevokeMode]].<br><br>
+ *
+ * Available options include:<br>
+ *  - [[RebalanceRevokeMode.Eager]] old behaviour, to release assigned partition as soon as possible,<br>
+ *  - [[RebalanceRevokeMode.Graceful]] modified behavior, waiting for configured amount of time:
+ *    {{{org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG}}} It is guaranteed by kafka protocol
+ *    that after that timeout old consumer will be marked as dead.
+ *
+ * Default mode is [[RebalanceRevokeMode.Eager]] which is exactly the same as old behavior and can be preferred
+ * if rebalance need to happen as quickly as possible and having multiple consumers working on a partition for a moment
+ * is not a problem.
+ *
+ * On the other hand if you want stricter guarantees about processing and attempt to wait for existing streams to finish
+ * processing messages before releasing partition choose [[RebalanceRevokeMode.Graceful]].
+ * Because stream is signalled to be shutdown in-flight commits might be lost and some messages might be processed again
+ * after new assignment.
+ *
+ */
+sealed abstract class RebalanceRevokeMode
+
+object RebalanceRevokeMode {
+
+  private[kafka] case object EagerMode extends RebalanceRevokeMode
+
+  private[kafka] case object GracefulMode extends RebalanceRevokeMode
+
+  /**
+   * Old behavior releasing partition as soon as all streams have messages dispatched and signalled termination
+   */
+  val Eager: RebalanceRevokeMode = EagerMode
+
+  /**
+   * Waiting for configured amount of time:<br>
+   *   {{{org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG}}} or until all the partition streams finish processing (but not waiting
+   *    for commits to conclude for that partition)
+   */
+  val Graceful: RebalanceRevokeMode = GracefulMode
+
+}

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -223,14 +223,24 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
         )).run(withRebalancing)
       }
       .flatMap { res =>
-        val onRevoked =
-          res.onRebalances.foldLeft(F.unit)(_ >> _.onRevoked(revoked))
+        val onRevokedStarted =
+          res.onRebalances.foldLeft(F.pure(Chain.empty[F[Unit]])) { (acc, next) =>
+            for {
+              acc <- acc
+              next <- next.onRevoked(revoked)
+            } yield acc ++ next
+          }
 
         res.logRevoked >>
           res.completeWithRecords >>
           res.completeWithoutRecords >>
           res.removeRevokedRecords >>
-          onRevoked
+          onRevokedStarted //first we need to trigger interruption for all the consuming streams
+            .flatMap(_.sequence_) //second we await for all the streams to finish processing (Eager mode returns immediately)
+            .timeoutTo(
+              settings.sessionTimeout,
+              ref.get.flatMap(state => log(LogEntry.RevokeTimeoutOccurred(revoked, state)))
+            )
       }
   }
 
@@ -630,7 +640,7 @@ private[kafka] object KafkaConsumerActor {
 
   final case class OnRebalance[F[_]](
     onAssigned: SortedSet[TopicPartition] => F[Unit],
-    onRevoked: SortedSet[TopicPartition] => F[Unit]
+    onRevoked: SortedSet[TopicPartition] => F[Chain[F[Unit]]],
   ) {
 
     override def toString: String =

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -223,6 +223,16 @@ private[kafka] object LogEntry {
 
   }
 
+  final case class RevokeTimeoutOccurred[F[_]](
+    revoked: Set[TopicPartition],
+    state: State[F, ?, ?]
+  ) extends LogEntry {
+    override def level: LogLevel = Info
+
+    override def message: String =
+      s"Consuming streams did not signal processing completion of [$revoked]. Current state [$state]."
+  }
+
   def recordsString[F[_]](
     records: Records[F]
   ): String =


### PR DESCRIPTION
This is potential solution for https://github.com/fd4s/fs2-kafka/issues/1200. Allowing for opting-in for graceful revoke handling (waiting for all the streams to finish, which should imply all the commits as well)